### PR TITLE
 Change TempDir to Use a Hash of Task Information for the Directory Name.

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -20,7 +20,7 @@ func TestTempDirsExist(t *testing.T) {
 func TestTempDir(t *testing.T) {
 	tsk := NewTask(nil, nil, "test_task", "echo foo", map[string]*FileIP{"in1": NewFileIP("infile.txt"), "in2": NewFileIP("infile2.txt")}, nil, nil, map[string]string{"p1": "p1val", "p2": "p2val"}, nil, "", nil, 4)
 
-	expected := tempDirPrefix + ".test_task.infile.txt.infile2.txt.p1_p1val.p2_p2val"
+	expected := tempDirPrefix + ".test_task.aaa94846ee057056e7f2d4d3aa2236bdf353d5a1"
 	actual := tsk.TempDir()
 	if actual != expected {
 		t.Errorf("TempDir() was %s Expected: %s", actual, expected)

--- a/utils.go
+++ b/utils.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"path/filepath"
 	re "regexp"
 	"time"
 
@@ -79,4 +80,16 @@ func errWrap(err error, msg string) error {
 
 func errWrapf(err error, msg string, v ...interface{}) error {
 	return errors.New(fmt.Sprintf(msg, v...) + "\nOriginal error: " + err.Error())
+}
+
+// splitAllPaths takes in a filepath and returns a list of all its parts
+// e.g. "/a/b/c" becomes ["a" "b" "c'"]
+func splitAllPaths(path string) []string {
+	dir, file := filepath.Dir(path), filepath.Base(path)
+	parts := []string{}
+	for dir != file {
+		parts = append([]string{file}, parts...)
+		dir, file = filepath.Dir(dir), filepath.Base(dir)
+	}
+	return parts
 }


### PR DESCRIPTION
Uses a hash instead of concatenating the relevant Task information to form the TempDir name.