### PR TITLE
[WIP] Windows Compatibility Fixes

### DIFF
--- a/components/file_combinator_test.go
+++ b/components/file_combinator_test.go
@@ -2,7 +2,9 @@ package components
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"log"
@@ -15,9 +17,14 @@ var numbers = []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", 
 
 func TestFileCombinator(t *testing.T) {
 
+	tmpDir, err := ioutil.TempDir("", "TestFileCombinator")
+	if err != nil {
+		log.Fatal("could not create tmpDir: ", err)
+	}
+
 	// Create letter files
 	for _, s := range letters {
-		fName := "/tmp/letterfile_" + s + ".txt"
+		fName := filepath.Join(tmpDir, "letterfile_"+s+".txt")
 		f, err := os.Create(fName)
 		if err != nil {
 			log.Fatalf("File could not be created: %s\n", fName)
@@ -27,7 +34,7 @@ func TestFileCombinator(t *testing.T) {
 
 	// Create number files
 	for _, s := range numbers {
-		fName := "/tmp/numberfile_" + s + ".txt"
+		fName := filepath.Join(tmpDir, "numberfile_"+s+".txt")
 		f, err := os.Create(fName)
 		if err != nil {
 			log.Fatalf("File could not be created: %s\n", fName)
@@ -38,8 +45,8 @@ func TestFileCombinator(t *testing.T) {
 	// Create workflow
 	wf := scipipe.NewWorkflow("wf", 4)
 
-	letterGlobber := NewFileGlobber(wf, "letter_globber", "/tmp/letterfile_*.txt")
-	numberGlobber := NewFileGlobber(wf, "number_globber", "/tmp/numberfile_*.txt")
+	letterGlobber := NewFileGlobber(wf, "letter_globber", filepath.Join(tmpDir, "letterfile_*.txt"))
+	numberGlobber := NewFileGlobber(wf, "number_globber", filepath.Join(tmpDir, "numberfile_*.txt"))
 
 	fileCombiner := NewFileCombinator(wf, "file_combiner")
 	fileCombiner.In("letters").From(letterGlobber.Out())
@@ -48,13 +55,13 @@ func TestFileCombinator(t *testing.T) {
 	catenator := wf.NewProc("catenator", "cat {i:letters} {i:numbers} > {o:combined}")
 	catenator.In("letters").From(fileCombiner.Out("letters"))
 	catenator.In("numbers").From(fileCombiner.Out("numbers"))
-	catenator.SetOut("combined", "/tmp/combined/{i:letters|basename|%.txt}.{i:numbers|basename|%.txt}.combined.txt")
+	catenator.SetOut("combined", filepath.Join(tmpDir, "combined", "{i:letters|basename|%.txt}.{i:numbers|basename|%.txt}.combined.txt"))
 
 	wf.Run()
 
 	for _, l := range letters {
 		for _, n := range numbers {
-			filePath := fmt.Sprintf("/tmp/combined/letterfile_%s.numberfile_%s.combined.txt", l, n)
+			filePath := fmt.Sprintf(filepath.Join(tmpDir, "combined", "letterfile_%s.numberfile_%s.combined.txt"), l, n)
 			if _, err := os.Stat(filePath); os.IsNotExist(err) {
 				log.Fatal("File did not exist: " + filePath)
 			}
@@ -64,17 +71,19 @@ func TestFileCombinator(t *testing.T) {
 	// Clean up files
 	filePaths := []string{}
 	for _, s := range letters {
-		filePaths = append(filePaths, fmt.Sprintf("/tmp/letterfile_%s.txt", s))
+		filePaths = append(filePaths, fmt.Sprintf(filepath.Join(tmpDir, "letterfile_%s.txt"), s))
 	}
 	for _, s := range numbers {
-		filePaths = append(filePaths, fmt.Sprintf("/tmp/numberfile_%s.txt", s))
+		filePaths = append(filePaths, fmt.Sprintf(filepath.Join(tmpDir, "numberfile_%s.txt"), s))
 	}
 	for _, l := range letters {
 		for _, n := range numbers {
-			filePaths = append(filePaths, fmt.Sprintf("/tmp/combined/letterfile_%s.numberfile_%s.combined.txt", l, n))
+			filePaths = append(filePaths, fmt.Sprintf(filepath.Join(tmpDir, "combined", "letterfile_%s.numberfile_%s.combined.txt"), l, n))
 			filePaths = append(filePaths, filePaths[len(filePaths)-1]+".audit.json")
 		}
 	}
+	filePaths = append(filePaths)
+
 	for _, filePath := range filePaths {
 		err := os.Remove(filePath)
 		if err != nil {

--- a/components/file_splitter.go
+++ b/components/file_splitter.go
@@ -86,7 +86,7 @@ func (p *FileSplitter) Run() {
 }
 
 func (p *FileSplitter) createNewSplitFile(ip *scipipe.FileIP, basePath string) (tempDir string, tempFile *os.File) {
-	tempPath := basePath + "/" + ip.TempPath()
+	tempPath := filepath.Join(basePath, ip.TempPath())
 	tempDir = filepath.Dir(tempPath)
 	err := os.MkdirAll(tempDir, 0777)
 	if err != nil {

--- a/components/file_to_params_reader_test.go
+++ b/components/file_to_params_reader_test.go
@@ -1,7 +1,10 @@
 package components
 
 import (
+	"io/ioutil"
+	"log"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/scipipe/scipipe"
@@ -10,9 +13,13 @@ import (
 var params = []string{"abc", "bcd", "cde"}
 
 func TestFileToParamsReader(tt *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "TestFileToParamsReader")
+	if err != nil {
+		log.Fatal("could not create tmpDir: ", err)
+	}
 	// Create file to read
-	filePath := "/tmp/filereader_testfile.txt"
-	f, err := os.Create("/tmp/filereader_testfile.txt")
+	filePath := filepath.Join(tmpDir, "filereader_testfile.txt")
+	f, err := os.Create(filePath)
 	if err != nil {
 		tt.Fatalf("Could not create file: %s", filePath)
 	}

--- a/ip.go
+++ b/ip.go
@@ -131,7 +131,7 @@ func (ip *FileIP) TempDir() string {
 
 // TempPath returns the temporary path of the physical file
 func (ip *FileIP) TempPath() string {
-	if ip.path[0] == '/' {
+	if filepath.IsAbs(ip.path) {
 		return FSRootPlaceHolder + ip.path
 	}
 	return ip.path

--- a/ip.go
+++ b/ip.go
@@ -288,12 +288,12 @@ func (ip *FileIP) Atomize() {
 	for !doneAtomizing {
 		if ip.TempFileExists() {
 			ip.lock.Lock()
-			tempPaths, err := filepath.Glob(ip.TempDir() + "/*")
-			CheckWithMsg(err, "Could not blog directory: "+ip.TempDir())
+			tempPaths, err := filepath.Glob(filepath.Join(ip.TempDir(), "*"))
+			CheckWithMsg(err, "Could not glob directory: "+ip.TempDir())
 			for _, tempPath := range tempPaths {
 				origDir := filepath.Dir(ip.TempDir())
 				origFileName := filepath.Base(tempPath)
-				err := os.Rename(tempPath, origDir+"/"+origFileName)
+				err := os.Rename(tempPath, filepath.Join(origDir, origFileName))
 				CheckWithMsg(err, "Could not rename file: "+ip.TempPath())
 			}
 			err = os.Remove(ip.TempDir())

--- a/task.go
+++ b/task.go
@@ -278,7 +278,7 @@ func (t *Task) createDirs() {
 		if oip.doStream {       // Temp dirs are not created for fifo files
 			oipDir = filepath.Dir(oip.FifoPath())
 		} else {
-			oipDir = t.TempDir() + "/" + oipDir
+			oipDir = filepath.Join(t.TempDir(), oipDir)
 		}
 		err := os.MkdirAll(oipDir, 0777)
 		CheckWithMsg(err, "Could not create directory: "+oipDir)
@@ -343,7 +343,7 @@ func AtomizeIPs(tempExecDir string, ips ...*FileIP) {
 	for _, oip := range ips {
 		// Move paths for ports, to final destinations
 		if !oip.doStream {
-			os.Rename(tempExecDir+"/"+oip.TempPath(), oip.Path())
+			os.Rename(filepath.Join(tempExecDir, oip.TempPath()), oip.Path())
 		}
 	}
 	// For remaining paths in temporary execution dir, just move out of it
@@ -362,7 +362,7 @@ func AtomizeIPs(tempExecDir string, ips ...*FileIP) {
 		return err
 	})
 	// Remove temporary execution dir (but not for absolute paths, or current dir)
-	if tempExecDir != "" && tempExecDir != "." && tempExecDir[0] != '/' {
+	if tempExecDir != "" && tempExecDir != "." && filepath.IsAbs(tempExecDir) {
 		remErr := os.RemoveAll(tempExecDir)
 		CheckWithMsg(remErr, "Could not remove temp dir: "+tempExecDir)
 	}

--- a/task_test.go
+++ b/task_test.go
@@ -69,7 +69,7 @@ func TestExtraFilesAtomizeAbsolute(t *testing.T) {
 		t.Fatal("could not create tmpDir: ", err)
 	}
 
-	absDir := filepath.Join(tmpDir, FSRootPlaceHolder, tmpDir)
+	absDir := filepath.Join(tmpDir, FSRootPlaceHolder, tmpDir, "1")
 	os.MkdirAll(absDir, 0777)
 	fName := filepath.Join(absDir, "letterfile_a.txt")
 	_, err = os.Create(fName)
@@ -77,7 +77,7 @@ func TestExtraFilesAtomizeAbsolute(t *testing.T) {
 		t.Fatalf("File could not be created: %s\n", fName)
 	}
 	AtomizeIPs(tmpDir)
-	filePath := filepath.Join(tmpDir, "letterfile_a.txt")
+	filePath := filepath.Join(tmpDir, "1", "letterfile_a.txt")
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
 		t.Error("File did not exist: " + filePath)
 	}

--- a/task_test.go
+++ b/task_test.go
@@ -1,7 +1,9 @@
 package scipipe
 
 import (
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -35,5 +37,52 @@ func TestTempDirNotOver255(t *testing.T) {
 	maxLen := 255
 	if actual > 256 {
 		t.Errorf("TempDir() generated too long a string: %d chars, should be max %d chars\nString was: %s", actual, maxLen, tsk.TempDir())
+	}
+}
+
+func TestExtraFilesAtomize(t *testing.T) {
+	// Since Atomize calls Debug, the logger needs to be non-nil
+	InitLogError()
+	tsk := NewTask(nil, nil, "test_task", "echo foo", map[string]*FileIP{}, nil, nil, map[string]string{}, nil, "", nil, 4)
+	// Create extra file
+	tmpDir := tsk.TempDir()
+	os.MkdirAll(tmpDir, 0777)
+	fName := filepath.Join(tmpDir, "letterfile_a.txt")
+	_, err := os.Create(fName)
+	if err != nil {
+		t.Fatalf("File could not be created: %s\n", fName)
+	}
+	tsk.atomizeIPs()
+	filePath := filepath.Join(".", "letterfile_a.txt")
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		t.Error("File did not exist: " + filePath)
+	}
+}
+
+func TestExtraFilesAtomizeAbsolute(t *testing.T) {
+	// Since Atomize calls Debug, the logger needs to be non-nil
+	InitLogError()
+
+	// Create extra file
+	tmpDir, err := ioutil.TempDir("", "TestExtraFilesAtomizeAbsolute")
+	if err != nil {
+		t.Fatal("could not create tmpDir: ", err)
+	}
+
+	absDir := filepath.Join(tmpDir, FSRootPlaceHolder, tmpDir)
+	os.MkdirAll(absDir, 0777)
+	fName := filepath.Join(absDir, "letterfile_a.txt")
+	_, err = os.Create(fName)
+	if err != nil {
+		t.Fatalf("File could not be created: %s\n", fName)
+	}
+	AtomizeIPs(tmpDir)
+	filePath := filepath.Join(tmpDir, "letterfile_a.txt")
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		t.Error("File did not exist: " + filePath)
+	}
+	// Ensure tmpDir wasn't removed by Atomize
+	if _, err := os.Stat(tmpDir); os.IsNotExist(err) {
+		t.Error("Atomize removed absolute directory")
 	}
 }


### PR DESCRIPTION
To Do:
- [x] Replace manual testing paths, path concatenation, and absolute tests with `ioutil.TempDir`, `filepath.Join`, and `filepath.IsAbs`, respectively.
- [ ] Find replacements for/configure Appveyor to handle GNU utilities like `sed`.
- [ ] Handle absolute Windows paths for output files vis a vis temp exec dirs.

Fixes #86