### PR TITLE
Hash SubStream IP Paths for TempDir

### DIFF
--- a/process.go
+++ b/process.go
@@ -160,6 +160,15 @@ func sortedStringMapKeys(kv map[string]string) []string {
 	return keys
 }
 
+func sortedFileIPSliceMapKeys(kv map[string][]*FileIP) []string {
+	keys := []string{}
+	for k := range kv {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 // ------------------------------------------------------------------------
 // Main API methods: Port accessor methods
 // ------------------------------------------------------------------------

--- a/task.go
+++ b/task.go
@@ -379,6 +379,11 @@ func (t *Task) TempDir() string {
 	for _, ipName := range sortedFileIPMapKeys(t.InIPs) {
 		hashPcs = append(hashPcs, splitAllPaths(t.InIP(ipName).Path())...)
 	}
+	for _, subIPName := range sortedFileIPSliceMapKeys(t.subStreamIPs) {
+		for _, subIPs := range t.subStreamIPs[subIPName] {
+			hashPcs = append(hashPcs, splitAllPaths(subIPs.Path())...)
+		}
+	}
 	for _, paramName := range sortedStringMapKeys(t.Params) {
 		hashPcs = append(hashPcs, paramName+"_"+t.Param(paramName))
 	}


### PR DESCRIPTION
Currently, the TempDir hashing does not take into account any information from SubStreams. If a Process has all of its inputs defined by a SubStream and no outputs (for example `echo := wf.NewProc("echo", "echo {i:in|join: }")`), then the TempDirs are not unique and the workflow errors.