### PR TITLE
Fix #71

### DIFF
--- a/workflow.go
+++ b/workflow.go
@@ -386,7 +386,7 @@ func (wf *Workflow) reconnectDeadEndConnections(procs map[string]WorkflowProcess
 		}
 	}
 
-	if foundNewDriverProc {
+	if foundNewDriverProc && len(procs) > 1 {  // Allow for a workflow with a single process
 		// A process can't both be the driver and be included in the main procs
 		// map, so if we have an alerative driver, it should not be in the main
 		// procs map

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -509,6 +509,14 @@ func TestSanitizePathFragments(t *testing.T) {
 	}
 }
 
+func TestSingleProcessWorkflow(t *testing.T) {
+  wf := NewWorkflow("mywf", 4)
+  wf.NewProc("file_creator", "echo foo > foo.txt")
+  wf.Run()
+
+  cleanFiles("foo.txt")
+}
+
 // --------------------------------------------------------------------------------
 // CombinatoricsProcess helper process
 // --------------------------------------------------------------------------------


### PR DESCRIPTION
This is a small fix in order to be able to have one process in a workflow.

A simple additional check for the number of processes seems to work but I am not sure though if that's not a part of some larger problem related to that.