### PR TITLE
delete minor unreachable code caused by log.Fatal

### DIFF
--- a/cmd/scipipe/main.go
+++ b/cmd/scipipe/main.go
@@ -24,7 +24,6 @@ func main() {
 	err := parseFlags(flag.Args())
 	if err != nil {
 		log.Fatalln(err.Error())
-		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

https://pkg.go.dev/log#Fatalln
> Fatalln is equivalent to Println() followed by a call to os.Exit(1).